### PR TITLE
Make limit atomic

### DIFF
--- a/lib/Redis/LeaderBoard.pm
+++ b/lib/Redis/LeaderBoard.pm
@@ -87,14 +87,11 @@ sub _set_expire_and_limit {
     $self->redis->expireat($self->key, $self->expire_at) if $self->expire_at;
 
     if ($self->limit) {
-        my $over = $self->member_count - $self->limit;
-        if ($over > 0) {
-            my ($from, $to) = (0, $over - 1);
-            if ($self->is_asc) {
-                ($from, $to) = (-$over, -1)
-            }
-            $self->redis->zremrangebyrank($self->key, $from, $to);
+        my ($from, $to) = (0, -$self->limit-1);
+        if ($self->is_asc) {
+            ($from, $to) = ($self->limit, -1)
         }
+        $self->redis->zremrangebyrank($self->key, $from, $to);
     }
 }
 

--- a/t/04_limit.t
+++ b/t/04_limit.t
@@ -21,6 +21,12 @@ subtest 'limit with desc' => sub {
     $redis_ranking->set_score(
         zero  => 0,
         one   => 1,
+    );
+    is $redis_ranking->member_count, 2;
+
+    $redis_ranking->set_score(
+        zero  => 0,
+        one   => 1,
         two   => 2,
         three => 3,
         four  => 4,
@@ -70,6 +76,12 @@ subtest 'limit with desc' => sub {
         limit => 3,
         order => 'asc',
     );
+
+    $redis_ranking->set_score(
+        zero  => 0,
+        one   => 1,
+    );
+    is $redis_ranking->member_count, 2;
 
     $redis_ranking->set_score(
         zero  => 0,


### PR DESCRIPTION
現在の実装は「メンバー数の確認」「あふれたメンバーの削除」がアトミックになっていないため、更新が同時実行されると削除しすぎてしまう可能性があります。
`zremrangebyrank`だけで実現できるのでは、と思ったので修正してみました。
